### PR TITLE
Make MessageReceiver an abstract class extending Oberservable.

### DIFF
--- a/src/main/java/com/hbm/devices/scan/AbstractMessageReceiver.java
+++ b/src/main/java/com/hbm/devices/scan/AbstractMessageReceiver.java
@@ -29,6 +29,7 @@
 package com.hbm.devices.scan;
 
 import java.io.Closeable;
+import java.util.Observable;
 
 /**
  * Interface for all message receivers.
@@ -36,16 +37,12 @@ import java.io.Closeable;
  *
  * @since 1.0
  */
-public interface MessageReceiver extends Runnable, Closeable {
-    /**
-     * Start receiving multicast messages.
-     */
-    @Override
-    void run();
+public abstract class AbstractMessageReceiver extends Observable implements Runnable, Closeable {
 
-    /**
-     * Stops receiveing multicast messages.
-     */
+    protected AbstractMessageReceiver() {
+        super();
+    }
+
     @Override
-    void close();
+    public abstract void close();
 }

--- a/src/main/java/com/hbm/devices/scan/MulticastMessageReceiver.java
+++ b/src/main/java/com/hbm/devices/scan/MulticastMessageReceiver.java
@@ -36,7 +36,6 @@ import java.net.MulticastSocket;
 import java.net.NetworkInterface;
 import java.nio.charset.Charset;
 import java.util.Collection;
-import java.util.Observable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -52,14 +51,14 @@ import com.hbm.devices.scan.ScanInterfaces;
  * Receiving messages is done infinitely when calling {@link #run() run()}. After calling
  * {@link #close() close()}, {@link #run() run()} returns.
  * <p>
- * In addition, via {@link com.hbm.devices.scan.MessageReceiver} this class is also an
+ * In addition, via {@link com.hbm.devices.scan.AbstractMessageReceiver} this class is also an
  * {@link java.util.Observable}. So objects which are interested in String multicast messages have
  * to implement the {@link java.util.Observer} interface and register themselves to an instance of
  * this class with addObserver().
  *
  * @since 1.0
  */
-public class MulticastMessageReceiver extends Observable implements MessageReceiver {
+public class MulticastMessageReceiver extends AbstractMessageReceiver {
 
     private InetAddress multicastIP;
     private int port;

--- a/src/test/java/com/hbm/devices/scan/FakeMessageReceiver.java
+++ b/src/test/java/com/hbm/devices/scan/FakeMessageReceiver.java
@@ -30,7 +30,6 @@ package com.hbm.devices.scan;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Observable;
 import java.util.Properties;
 import java.util.logging.Logger;
 
@@ -40,7 +39,7 @@ import java.util.logging.Logger;
  *
  * @since 1.0
  */
-public class FakeMessageReceiver extends Observable implements MessageReceiver {
+public class FakeMessageReceiver extends AbstractMessageReceiver {
 
     private boolean shallRun = true;
     private static final Logger LOGGER = Logger.getLogger(ScanConstants.LOGGER_NAME);

--- a/src/test/java/com/hbm/devices/scan/StressTestMessageReceiver.java
+++ b/src/test/java/com/hbm/devices/scan/StressTestMessageReceiver.java
@@ -30,13 +30,12 @@ package com.hbm.devices.scan;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Observable;
 import java.util.UUID;
 import java.util.logging.Logger;
 
 import com.hbm.devices.scan.ScanConstants;
 
-public class StressTestMessageReceiver extends Observable implements MessageReceiver {
+public class StressTestMessageReceiver extends AbstractMessageReceiver {
 
     private final List<String> deviceUuidList;
     private final int loopAmount;
@@ -98,5 +97,4 @@ public class StressTestMessageReceiver extends Observable implements MessageRece
     @Override
     public void close() {
     }
-
 }

--- a/src/test/java/com/hbm/devices/scan/configure/FakeDeviceEmulator.java
+++ b/src/test/java/com/hbm/devices/scan/configure/FakeDeviceEmulator.java
@@ -28,9 +28,7 @@
 
 package com.hbm.devices.scan.configure;
 
-import java.util.Observable;
-
-import com.hbm.devices.scan.MessageReceiver; 
+import com.hbm.devices.scan.AbstractMessageReceiver; 
 
 /**
  * This class is used to simulate a device.
@@ -43,7 +41,7 @@ import com.hbm.devices.scan.MessageReceiver;
  * @since 1.0
  *
  */
-public class FakeDeviceEmulator extends Observable implements MessageReceiver, MulticastSender {
+public class FakeDeviceEmulator extends AbstractMessageReceiver implements MulticastSender {
 
     private String responseString;
 	private boolean closed;
@@ -55,6 +53,7 @@ public class FakeDeviceEmulator extends Observable implements MessageReceiver, M
 	}
     public void stop() {}
     public void run() {}
+    @Override
     public void close() {closed = true;}
     public boolean isClosed() {return closed;}
     public void sendMessage(String message) {


### PR DESCRIPTION
This make it much easier to interchange MulticastMessageReceiver and
FakeMessageReceiver in code using this library.