### PR TITLE
Interface: added missing field "configurationMethod"; fixed misspelling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 cscope.*
 .gradle
+build
 *.swp
+/.classpath
+/.project
+/.settings

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.hbm.devices</groupId>
   <artifactId>devscan</artifactId>
-  <version>1.0</version>
+  <version>1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>HBM device scan library for Java</name>
@@ -51,6 +51,11 @@
       </plugin>
     </plugins>
     <directory>build</directory>
+    <testResources>
+      <testResource>
+        <directory>src/example</directory>
+      </testResource>
+    </testResources>
   </build>
 
   <dependencies>

--- a/src/main/java/com/hbm/devices/scan/announce/Interface.java
+++ b/src/main/java/com/hbm/devices/scan/announce/Interface.java
@@ -31,9 +31,9 @@ package com.hbm.devices.scan.announce;
 import java.util.List;
 
 /**
- * Objects of this class hold the inforamtion describing the properties
+ * Objects of this class hold the information describing the properties
  * of an network interface.
- * 
+ *
  * @since 1.0
  */
 public final class Interface {
@@ -41,6 +41,7 @@ public final class Interface {
     private String name;
     private String type;
     private String description;
+    private String configurationMethod;
     private List<IPv4Entry> ipv4;
     private List<IPv6Entry> ipv6;
 
@@ -63,7 +64,7 @@ public final class Interface {
 
     /**
      * @return
-     *      Astring containing the type of the interface or {@code null} if not
+     *      A string containing the type of the interface or {@code null} if not
      *      announced.
      *      For QuantumX systems it might be useful to distinguish
      *      Ethernet and Firewire interfaces.
@@ -74,7 +75,7 @@ public final class Interface {
 
     /**
      * @return
-     *      Astring containing some additional
+     *      A string containing some additional
      *      information or {@code null} if not announced. QuantumX devices
      *      report whether the
      *      interface is on the front or back side.
@@ -82,6 +83,16 @@ public final class Interface {
     public String getDescription() {
         return description;
     }
+
+    /**
+     * @return
+     *   A string enumeration describing how the network settings configured
+     *   on the device during the startup. Currently the values manual, dhcp
+     *   and RouterSolicitation are valid.
+     */
+    public String getConfigurationMethod() {
+		return configurationMethod;
+	}
 
     /**
      * @return


### PR DESCRIPTION
JSON structure sent by QuantumX devices contains this field and we need it ;)