### PR TITLE
Don't include gson classes in devscan.jar.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,6 @@ artifacts {
 
 jar {
 	archiveName = jar.baseName + '.' + jar.extension
-	from configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
 	exclude ('fakemessages.properties')
 	manifest {
 		attributes \


### PR DESCRIPTION
Otherwise, multiple android dex files define the gson classes.