### PR TITLE
Ignore announces with a negative expiration.

### DIFF
--- a/devscan/src/main/java/com/hbm/devices/scan/announce/AnnounceDeserializer.java
+++ b/devscan/src/main/java/com/hbm/devices/scan/announce/AnnounceDeserializer.java
@@ -88,6 +88,9 @@ public final class AnnounceDeserializer extends Observable implements Observer {
                 announce = (Announce)gson.fromJson(message, JsonRpc.class);
                 if (announce != null) {
                     announce.identifyCommunicationPath();
+                    if (announce.getParams().getExpiration() < 0) {
+                        return;
+                    }
                     announceCache.put(message, announce);
                     setChanged();
                     notifyObservers(announce);

--- a/devscan/src/main/java/com/hbm/devices/scan/announce/AnnounceParams.java
+++ b/devscan/src/main/java/com/hbm/devices/scan/announce/AnnounceParams.java
@@ -113,7 +113,7 @@ public final class AnnounceParams implements Serializable {
     }
 
     public int getExpiration() {
-        if (expiration <= 0) {
+        if (expiration == 0) {
             return ScanConstants.DEFAULT_EXPIRATION_S;
         }
         return expiration;

--- a/devscan/src/test/java/AnnounceParamsTest.java
+++ b/devscan/src/test/java/AnnounceParamsTest.java
@@ -78,8 +78,7 @@ public class AnnounceParamsTest {
     @Test
     public void parseNegativeExpiration() {
         fsmmr.emitNegativeExpiration();
-        assertNotNull("Got no Announce object after message with negative expiration", announce);
-        assertEquals("negative expiration in announce does't lead to default expiration", announce.getParams().getExpiration(), ScanConstants.DEFAULT_EXPIRATION_S);
+        assertNull("Got no Announce object after message with negative expiration", announce);
     }
 
     @Test


### PR DESCRIPTION
Announces with a deliberitly wrong set expiration are malicious.
Just ignore such packets.