### PR TITLE
Take out sonarqube plugin.

### DIFF
--- a/devscan/build.gradle
+++ b/devscan/build.gradle
@@ -11,7 +11,6 @@ buildscript {
 plugins {
 	id "com.github.kt3k.coveralls" version "2.6.3"
 	id "maven"
-	id "org.sonarqube" version "2.2"
 	id "signing"
 }
 

--- a/receiver/build.gradle
+++ b/receiver/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-	id "org.sonarqube" version "2.2"
 }
 
 dependencies {

--- a/sender/build.gradle
+++ b/sender/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-	id "org.sonarqube" version "2.2"
 }
 
 description 'An example to use the devscan library to configure a device.'


### PR DESCRIPTION
This plugin requires Java 8, but we need to build for java 7 (Android.)