### PR TITLE
ScanInterfaces with predicate

### DIFF
--- a/devscan/build.gradle
+++ b/devscan/build.gradle
@@ -43,6 +43,7 @@ processResources {
 
 dependencies {
 	compile group: 'com.google.code.gson', name: 'gson', version: '2.8.1'
+	compile group: 'com.google.guava', name: 'guava', version: '20.0'
 	testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/devscan/src/main/java/com/hbm/devices/scan/ScanInterfaces.java
+++ b/devscan/src/main/java/com/hbm/devices/scan/ScanInterfaces.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
@@ -92,8 +93,7 @@ public final class ScanInterfaces {
     }
 
     private static Iterable<NetworkInterface> getAllNetworkInterfaces() throws SocketException {
-        final Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
-        return networkInterfaces == null ? Collections.<NetworkInterface>emptyList() : Collections.list(networkInterfaces);
+        return Collections.list(Optional.fromNullable(NetworkInterface.getNetworkInterfaces()).or(Collections.<NetworkInterface>emptyEnumeration()));
     }
 
     private static boolean willScan(NetworkInterface iface) throws SocketException {

--- a/devscan/src/main/java/com/hbm/devices/scan/ScanInterfaces.java
+++ b/devscan/src/main/java/com/hbm/devices/scan/ScanInterfaces.java
@@ -72,8 +72,7 @@ public final class ScanInterfaces {
      *             if an I/O error occurs.
      */
     public ScanInterfaces(Predicate<NetworkInterface> ifacePredicate) throws SocketException {
-    	
-        Builder<NetworkInterface> interfacesBuilder = ImmutableList.<NetworkInterface>builder();
+        Builder<NetworkInterface> interfacesBuilder = ImmutableList.<NetworkInterface> builder();
         for (NetworkInterface iface : Iterables.filter(getAllNetworkInterfaces(), ifacePredicate)) {
             if (willScan(iface)) {
                 interfacesBuilder.add(iface);

--- a/devscan/src/main/java/com/hbm/devices/scan/ScanInterfaces.java
+++ b/devscan/src/main/java/com/hbm/devices/scan/ScanInterfaces.java
@@ -35,50 +35,66 @@ import java.net.SocketException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.LinkedList;
 import java.util.List;
+
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.Iterables;
 
 /**
  * Convenience class to gather all network interfaces eligible for multicast scanning &amp; sending.
- * 
+ *
  * @since 1.0
  */
 public final class ScanInterfaces {
-
     private final List<NetworkInterface> interfaces;
 
     /**
      * Constructs an object containing all network interfaces eligible
-     * for multicast scanning @amp; sending.
+     * for multicast scanning &amp; sending.
      *
      * @throws SocketException if an I/O error occurs.
      */
     public ScanInterfaces() throws SocketException {
-        interfaces = new LinkedList<>();
-        final Enumeration<NetworkInterface> ifs = NetworkInterface.getNetworkInterfaces();
-
-        if (ifs != null) {
-            while (ifs.hasMoreElements()) {
-                final NetworkInterface iface = ifs.nextElement();
-                if (willScan(iface)) {
-                    interfaces.add(iface);
-                }
-            }
-        }
+        this(Predicates.<NetworkInterface>alwaysTrue());
     }
 
     /**
-     * @return an {@link java.util.Collections#unmodifiableCollection(Collection c) unmodifiable Collection}
+     * Constructs an object containing all network interfaces eligible for multicast scanning &amp;
+     * sending and fullfilling the conditions specified by the given predicate.
+     *
+     * @param ifacePredicate
+     *            is called before doing checks on the interface reg. its awareness for multicast
+     *            scanning. So the caller may inject own filter criteria.
+     * @throws SocketException
+     *             if an I/O error occurs.
+     */
+    public ScanInterfaces(Predicate<NetworkInterface> ifacePredicate) throws SocketException {
+    	
+        Builder<NetworkInterface> interfacesBuilder = ImmutableList.<NetworkInterface>builder();
+        for (NetworkInterface iface : Iterables.filter(getAllNetworkInterfaces(), ifacePredicate)) {
+            if (willScan(iface)) {
+                interfacesBuilder.add(iface);
+            }
+        }
+        interfaces = interfacesBuilder.build();
+    }
+
+    /**
+     * @return an {@link ImmutableList immutable list}
      * of {@link java.net.NetworkInterface NetworkInterfaces} usable for
      * Multicast scanning. If no interface was found, an empty
-     * {@link java.util.Collection} is returned.
+     * {@link ImmutableList immutable list} is returned.
      */
     public Collection<NetworkInterface> getInterfaces() {
-        if (interfaces == null) {
-            return new LinkedList<>();
-        } else {
-            return Collections.unmodifiableCollection(interfaces);
-        }    
+        return interfaces;
+    }
+
+    private static Iterable<NetworkInterface> getAllNetworkInterfaces() throws SocketException {
+        final Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+        return networkInterfaces == null ? Collections.<NetworkInterface>emptyList() : Collections.list(networkInterfaces);
     }
 
     private static boolean willScan(NetworkInterface iface) throws SocketException {

--- a/devscan/src/main/java/com/hbm/devices/scan/announce/AnnounceReceiver.java
+++ b/devscan/src/main/java/com/hbm/devices/scan/announce/AnnounceReceiver.java
@@ -29,7 +29,9 @@
 package com.hbm.devices.scan.announce;
 
 import java.io.IOException;
+import java.net.NetworkInterface;
 
+import com.google.common.base.Predicate;
 import com.hbm.devices.scan.MulticastMessageReceiver;
 import com.hbm.devices.scan.ScanConstants;
 
@@ -52,5 +54,21 @@ public final class AnnounceReceiver extends MulticastMessageReceiver {
      */
     public AnnounceReceiver() throws IOException {
         super(ScanConstants.ANNOUNCE_ADDRESS, ScanConstants.ANNOUNCE_PORT);
+    }
+
+    /**
+     * Constructs an {@code AnnounceReceiver} object.
+     *
+     * @param ifacePredicate custom filter to be applied to each available network interface
+     *        before checking its multicast capability.
+     *
+     * @throws java.io.IOException if the AnnounceReceiver can't
+     * created. This might happen if the underlying socket can't be
+     * created or the multicast join was not successful.
+     *
+     * @since 1.0
+     */
+    public AnnounceReceiver(Predicate<NetworkInterface> ifacePredicate) throws IOException {
+        super(ScanConstants.ANNOUNCE_ADDRESS, ScanConstants.ANNOUNCE_PORT, ifacePredicate);
     }
 }

--- a/devscan/src/test/java/AnnounceReceiverTest.java
+++ b/devscan/src/test/java/AnnounceReceiverTest.java
@@ -34,7 +34,9 @@ import static org.junit.Assert.assertNull;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.net.NetworkInterface;
 
+import com.google.common.base.Predicates;
 import com.hbm.devices.scan.announce.AnnounceReceiver;
 
 public class AnnounceReceiverTest {
@@ -42,6 +44,11 @@ public class AnnounceReceiverTest {
     @Test
     public void intantiation() {
         try (final AnnounceReceiver ar = new AnnounceReceiver()) {
+            assertNotNull("Could not instantiate AnnounceReceiver", ar);
+        } catch (IOException e) {
+            fail("Got IOException while instantiating AnnounceReceiver");
+        }
+        try (final AnnounceReceiver ar = new AnnounceReceiver(Predicates.<NetworkInterface>alwaysFalse())) {
             assertNotNull("Could not instantiate AnnounceReceiver", ar);
         } catch (IOException e) {
             fail("Got IOException while instantiating AnnounceReceiver");

--- a/devscan/src/test/java/ConfigurationMulticastSenderTest.java
+++ b/devscan/src/test/java/ConfigurationMulticastSenderTest.java
@@ -73,7 +73,7 @@ public class ConfigurationMulticastSenderTest {
                     }
                 }
             };
-            final Collection<NetworkInterface> sendInterfaces = new ScanInterfaces().getInterfaces();
+            final Collection<NetworkInterface> sendInterfaces = new ScanInterfaces(predicate).getInterfaces();
             for (NetworkInterface sendInterface : sendInterfaces) {
                 assertTrue("Predicate wasn't applied as expected", predicate.apply(sendInterface));
             }

--- a/devscan/src/test/java/ConfigurationMulticastSenderTest.java
+++ b/devscan/src/test/java/ConfigurationMulticastSenderTest.java
@@ -63,20 +63,20 @@ public class ConfigurationMulticastSenderTest {
     @Test
     public void createWithFilter() {
         try {
-        	Predicate<NetworkInterface> predicate = new Predicate<NetworkInterface>() {
-				@Override
-				public boolean apply(NetworkInterface networkInterface) {
-					try {
-						return networkInterface.getHardwareAddress() != null;
-					} catch (SocketException e) {
-						return false;
-					}
-				}
-			};
+            Predicate<NetworkInterface> predicate = new Predicate<NetworkInterface>() {
+                @Override
+                public boolean apply(NetworkInterface networkInterface) {
+                    try {
+                        return networkInterface.getHardwareAddress() != null;
+                    } catch (SocketException e) {
+                        return false;
+                    }
+                }
+            };
             final Collection<NetworkInterface> sendInterfaces = new ScanInterfaces().getInterfaces();
             for (NetworkInterface sendInterface : sendInterfaces) {
-            	assertTrue("Predicate wasn't applied as expected", predicate.apply(sendInterface));
-			}
+                assertTrue("Predicate wasn't applied as expected", predicate.apply(sendInterface));
+            }
         } catch (IOException e) {
             fail("Can't instantiate ConfigurationMulticastSender object");
         }
@@ -84,14 +84,14 @@ public class ConfigurationMulticastSenderTest {
 
     @Test
     public void createAndClose() {
-    	try {
-    		final Collection<NetworkInterface> sendInterfaces = new ScanInterfaces().getInterfaces();
-    		ConfigurationMulticastSender sender = new ConfigurationMulticastSender(sendInterfaces);
-    		sender.close();
-    		assertTrue("ConfigurationMulticastSender was not closed", sender.isClosed());
-    	} catch (IOException e) {
-    		fail("Can't instantiate ConfigurationMulticastSender object");
-    	}
+        try {
+            final Collection<NetworkInterface> sendInterfaces = new ScanInterfaces().getInterfaces();
+            ConfigurationMulticastSender sender = new ConfigurationMulticastSender(sendInterfaces);
+            sender.close();
+            assertTrue("ConfigurationMulticastSender was not closed", sender.isClosed());
+        } catch (IOException e) {
+            fail("Can't instantiate ConfigurationMulticastSender object");
+        }
     }
 
     @Test

--- a/devscan/src/test/java/com/hbm/devices/scan/DeviceScanTest.java
+++ b/devscan/src/test/java/com/hbm/devices/scan/DeviceScanTest.java
@@ -2,14 +2,16 @@ package com.hbm.devices.scan;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.junit.Before;
 import org.junit.Test;
 
 public class DeviceScanTest {
-
+    @Test
+    public void utilityClassTest() {
+        TestCommons.assertUtilityClassWellDefined(DeviceScanTest.class);
+    }
+    
     @Test
     public void versionTest() {
         try {

--- a/devscan/src/test/java/com/hbm/devices/scan/DeviceScanTest.java
+++ b/devscan/src/test/java/com/hbm/devices/scan/DeviceScanTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 public class DeviceScanTest {
     @Test
     public void utilityClassTest() {
-        TestCommons.assertUtilityClassWellDefined(DeviceScanTest.class);
+        TestCommons.assertUtilityClassWellDefined(DeviceScan.class);
     }
     
     @Test

--- a/devscan/src/test/java/com/hbm/devices/scan/TestCommons.java
+++ b/devscan/src/test/java/com/hbm/devices/scan/TestCommons.java
@@ -1,0 +1,51 @@
+package com.hbm.devices.scan;
+
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+// I'd prefer the default package as location but the compiler didn't accept it
+public class TestCommons
+{
+    /**
+     * Verifies that a utility class is well defined.
+     * 
+     * @param clazz
+     *            utility class to verify.
+     */
+    public static void assertUtilityClassWellDefined(final Class<?> clazz) {
+        assertTrue("class must be final", Modifier.isFinal(clazz.getModifiers()));
+        assertEquals("There must be only one constructor", 1, clazz.getDeclaredConstructors().length);
+        Constructor<?> constructor;
+        try {
+            constructor = clazz.getDeclaredConstructor();
+        } catch (NoSuchMethodException e) {
+            fail("empty constructor expected");
+            return;
+        } catch (SecurityException e) {
+            fail("Test requires access to declared constructor");
+            return;
+        }
+        if (constructor.isAccessible() || !Modifier.isPrivate(constructor.getModifiers())) {
+            fail("constructor is not private");
+        }
+        constructor.setAccessible(true);
+        try {
+            constructor.newInstance();
+        } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
+            // accepted exceptions
+        }
+        constructor.setAccessible(false);
+        for (final Method method : clazz.getMethods()) {
+            if (!Modifier.isStatic(method.getModifiers()) && method.getDeclaringClass().equals(clazz)) {
+                fail("there exists a non-static method:" + method);
+            }
+        }
+    }
+}


### PR DESCRIPTION
As discussed in May 2017 ScanInterfaces should provide a constructor with predicate e.g. to be able to exclude NetworkInterface without expression in hardware. 

Original Issue:
wir haben bei uns ein Problem  mit der devScan API auf einem Windows Testsystem, wo wir im Moment nicht weiterkommen:
Der Aufruf von AnnounceReceiver.joinOnAllInterfaces(MulticastSocket) sowie leaveOnAllInterfaces(MulticastSocket) blockiert unter nicht nachvollziehbaren Umständen jeweils für viele Minuten, da new ScanInterfaces() für jedes Interface willScan(NetworkInterface) aufruft, was auf diesem System für diverse „WAN-Miniport …“ Adapter lange hängt (Konkret iface.isUp()). Besteht die Möglichkeit, hier noch eine Vorfilterung durchzuführen, z.B. nur Adapter mit einer Hardware Adresse (NetworkInterface.getHardwareAddress()) zu berücksichtigen? Das könnte unser Problem möglicherweise lösen.
